### PR TITLE
fix: Changed return type of the return_hexadecimal function

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -76,7 +76,7 @@ def element_wise_multiply(a: np.array, b: np.array) -> np.array:
 
     return np.multiply(a, b)
 
-def return_hexadecimal(a: int) -> float:
+def return_hexadecimal(a: int) -> str:
     '''
     ...
 


### PR DESCRIPTION
# Description
Updated the return type of the return_hexadecimal function.

*If the issue is on Github, simply link to it using the '#' symbol)*:
- resolves #3 

# Remarks (Optional)
-Nice PR
